### PR TITLE
[CLOUD-2413] remove material now included in modules

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -75,13 +75,6 @@ modules:
           - name: os-amq-permissions
           - name: openshift-passwd
           - name: os-logging
-packages:
-      repositories:
-          - jboss-os
-          - jboss-ocp
-          - jboss-rhscl
-      install:
-          - PyYAML
 
 run:
       user: 185

--- a/image.yaml
+++ b/image.yaml
@@ -43,48 +43,9 @@ envs:
     - name: AMQ_NEED_CLIENT_AUTH
       example: false
       description: "Sets SSL to require client authentication"
-    - name: "JAVA_OPTS_APPEND"
-      example: "-Dactivemq.foo=bar"
-      description: "Server startup options."
     - name: SCRIPT_DEBUG
       description: If set to true, ensurses that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed.
       example: "true"
-    - name: JAVA_MAX_MEM_RATIO
-      description: This is used to calculate a default maximal heap memory based on a containers restriction. If used in a container without any memory constraints for the container then this option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio of the container available memory as set here. The default is `50` which means 50% of the available memory is used as an upper boundary. You can skip this mechanism by setting this value to `0` in which case no `-Xmx` option is added.
-      example: "50"
-    - name: JAVA_INITIAL_MEM_RATIO
-      description: This is used to calculate a default initial heap memory based the maximumal heap memory.  The default is `100` which means 100% of the maximal heap is used for the initial heap size.  You can skip this mechanism by setting this value to `0` in which case no `-Xms` option is added.
-      example: "100"
-    - name: JAVA_MAX_INITIAL_MEM
-      description: The maximum size of the initial heap memory, if the calculated default initial heap is larger then it will be capped at this value.  The default is 4096 MB.
-      example: "4096"
-    - name: JAVA_CORE_LIMIT
-      description: Core limit as described in https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt.  Used to configure the number of GC threads and parallelism for ForkJoinPool.  Defaults to container core limit.
-      example: "2"
-    - name: JAVA_DIAGNOSTICS
-      description: Set this to get some diagnostics information to standard output when things are happening. **Disabled by default.**
-      example: "true"
-    - name: GC_MIN_HEAP_FREE_RATIO
-      description: Minimum percentage of heap free after GC to avoid expansion.
-      example: "20"
-    - name: GC_MAX_HEAP_FREE_RATIO
-      description: Maximum percentage of heap free after GC to avoid shrinking.
-      example: "40"
-    - name: GC_TIME_RATIO
-      description: Specifies the ratio of the time spent outside the garbage collection (for example, the time spent for application execution) to the time spent in the garbage collection.
-      example: "4"
-    - name: GC_ADAPTIVE_SIZE_POLICY_WEIGHT
-      description: The weighting given to the current GC time versus previous GC times.
-      example: "90"
-    - name: GC_MAX_METASPACE_SIZE
-      description: The maximum metaspace size.
-      example: "100"
-    - name: "CONTAINER_HEAP_PERCENT"
-      example: 0.5
-      description: Deprecated.  See JAVA_MAX_MEM_RATIO.
-    - name: "INITIAL_HEAP_PERCENT"
-      example: 0.5
-      description: Deprecated.  See JAVA_INITIAL_MEM_RATIO.
 ports:
     - value: 5672
     - value: 5671


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2413

This is a partner PR for https://github.com/jboss-openshift/cct_module/pull/222.

This should be an effective no-op for the image sources.

The way to test is:
 * from amq63-dev branch, run `condev generate` and save the `target` folder output
 * clone my cct_module fork (that branch specifically)  into a checkout of this image sources, and edit image.yaml so the cct_module bit under "repositories:" only reads `path: cct_module`. This means it will use the local version.  to compare `condev generate` output before and after (in particular the `Dockerfile`).
 * run `condev generate` again, and compare the target folder to your saved one
