### PR TITLE
CLOUD-2957 Move AMQ modules out of cct_module

### DIFF
--- a/content_sets.yml
+++ b/content_sets.yml
@@ -1,0 +1,17 @@
+# This is a file defining which content sets (yum repositories) are needed to
+# update content in this image. Data provided here helps determine which images
+# are vulnerable to specific CVEs. Generally you should only need to update this
+# file when:
+#    1. You start depending on a new product
+#    2. You are preparing new product release and your content sets will change
+#
+# See https://mojo.redhat.com/docs/DOC-1023066 for more information on
+# maintaining this file and the format and examples
+#
+# You should have one top level item for each architecture being built. Most
+# likely this will be x86_64 and ppc64le initially.
+---
+x86_64:
+- rhel-server-rhscl-7-rpms
+- rhel-7-server-rpms
+

--- a/image.yaml
+++ b/image.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "jboss-amq-6/amq63-openshift"
 description: "Red Hat JBoss AMQ 6.3 OpenShift container image"
-version: "1.4"
+version: "1.5"
 from: "jboss-amq-6/amq63:latest"
 labels:
     - name: "com.redhat.component"
@@ -57,31 +57,41 @@ ports:
     - value: 61617
 modules:
       repositories:
+          - path: modules
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
                   ref: master
+          - name: jboss-eap-modules
+            git:
+                  url: https://github.com/jboss-container-images/jboss-eap-modules.git
+                  ref: master
       install:
           - name: dynamic-resources
-          - name: os-amq-secure-mgmt-console
-          - name: os-amq-optional
+          - name: md-amq-secure-mgmt-console
+          - name: md-amq-optional
           - name: os-java-run
-          - name: os-amq-launch
+          - name: md-amq-launch
           - name: os-partition
           - name: os-java-jolokia
-          - name: os-amq-jolokia
-          - name: os-amq-s2i
-          - name: os-amq-permissions
+          - name: md-amq-jolokia
+          - name: md-amq-s2i
+          - name: md-amq-permissions
           - name: openshift-passwd
           - name: os-logging
 packages:
-      repositories:
-          - jboss-os
+      content_sets_file: content_sets.yml
 run:
       user: 185
       cmd:
           - "/opt/amq/bin/launch.sh"
 osbs:
+      configuration:
+          container:
+              compose:
+                  pulp_repos: true
       repository:
-            name: containers/jboss-amq-6
-            branch: jb-amq-6.3-openshift-rhel-7
+          name: containers/jboss-amq-6
+          branch: jb-amq-6.3-openshift-rhel-7
+
+

--- a/modules/md-amq-jolokia/install.sh
+++ b/modules/md-amq-jolokia/install.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Add Jolokia (http://www.jolokia.org/) to expose all MBeans
+set -e
+
+SOURCES_DIR="/tmp/artifacts"
+
+# for backward compatibility.  jolokia is now located in /opt/jolokia.
+ln -s /opt/jolokia/jolokia.jar $AMQ_HOME/jolokia.jar

--- a/modules/md-amq-jolokia/module.yaml
+++ b/modules/md-amq-jolokia/module.yaml
@@ -1,0 +1,6 @@
+schema_version: 1
+name: md-amq-jolokia
+version: '1.0'
+description: Legacy md-amq-jolokia script package migrated from cct_module's os-amq-jolokia.
+execute:
+- script: install.sh

--- a/modules/md-amq-launch/added/configure.sh
+++ b/modules/md-amq-launch/added/configure.sh
@@ -1,0 +1,247 @@
+#!/bin/sh
+
+source $AMQ_HOME/bin/launch/logging.sh
+
+OPENSHIFT_CONFIG_FILE=$AMQ_HOME/conf/openshift-activemq.xml
+CONFIG_FILE=$AMQ_HOME/conf/activemq.xml
+OPENSHIFT_LOGIN_FILE=$AMQ_HOME/conf/openshift-login.config
+LOGIN_FILE=$AMQ_HOME/conf/login.config
+OPENSHIFT_USERS_FILE=$AMQ_HOME/conf/openshift-users.properties
+USERS_FILE=$AMQ_HOME/conf/users.properties
+USERS_DNAME_FILE=$AMQ_HOME/conf/users-dname.properties
+
+function configure_passwd() {
+  sed "/^jboss/s/[^:]*/$(id -u)/3" /etc/passwd > /tmp/passwd
+  cat /tmp/passwd > /etc/passwd
+  rm /tmp/passwd
+}
+
+# Finds the environment variable  and returns its value if found.
+# Otherwise returns the default value if provided.
+#
+# Arguments:
+# $1 env variable name to check
+# $2 default value if environemnt variable was not set
+function find_env() {
+  var=${!1}
+  echo "${var:-$2}"
+}
+
+function checkViewEndpointsPermission() {
+    if [ "${AMQ_MESH_DISCOVERY_TYPE}" = "kube" ]; then
+        if [ -n "${AMQ_MESH_SERVICE_NAMESPACE+_}" ] && [ -n "${AMQ_MESH_SERVICE_NAME+_}" ]; then
+            endpointsUrl="https://${KUBERNETES_SERVICE_HOST:-kubernetes.default.svc}:${KUBERNETES_SERVICE_PORT:-443}/api/v1/namespaces/${AMQ_MESH_SERVICE_NAMESPACE}/endpoints/${AMQ_MESH_SERVICE_NAME}"
+            endpointsAuth="Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+            endpointsCode=$(curl -s -o /dev/null -w "%{http_code}" -G -k -H "${endpointsAuth}" ${endpointsUrl})
+            if [ "${endpointsCode}" = "200" ]; then
+                log_info "Service account has sufficient permissions to view endpoints in kubernetes (HTTP ${endpointsCode}). Mesh will be available."
+            elif [ "${endpointsCode}" = "403" ]; then
+                log_warning "Service account has insufficient permissions to view endpoints in kubernetes (HTTP ${endpointsCode}). Mesh will be unavailable. Please refer to the documentation for configuration."
+            else
+                log_warning "Service account unable to test permissions to view endpoints in kubernetes (HTTP ${endpointsCode}). Mesh will be unavailable. Please refer to the documentation for configuration."
+            fi
+        else
+            log_warning "Environment variables AMQ_MESH_SERVICE_NAMESPACE and AMQ_MESH_SERVICE_NAME both need to be defined when using AMQ_MESH_DISCOVERY_TYPE=\"kube\". Mesh will be unavailable. Please refer to the documentation for configuration."
+        fi
+    fi
+}
+
+function configureMesh() {
+  serviceName="${AMQ_MESH_SERVICE_NAME}"
+  username="${AMQ_USER}"
+  password="${AMQ_PASSWORD}"
+  dname="${AMQ_DNAME}"
+  discoveryType="${AMQ_MESH_DISCOVERY_TYPE:-dns}"
+  queryInterval="${AMQ_MESH_QUERY_INTERVAL:-30}"
+
+  if [ -n "${serviceName}" ] ; then
+    networkConnector=""
+    if [ -n "${username}" -a -n "${password}" ] ; then
+      networkConnector="<networkConnector userName=\"${username}\" password=\"${password}\" uri=\"${discoveryType}://${serviceName}:61616/?transportType=tcp\&amp;queryInterval=${queryInterval}\" messageTTL=\"-1\" consumerTTL=\"1\" />"
+    else
+      networkConnector="<networkConnector uri=\"${discoveryType}://${serviceName}:61616/?transportType=tcp\&amp;queryInterval=${queryInterval}\" messageTTL=\"-1\" consumerTTL=\"1\" />"
+    fi
+    sed -i "s|<!-- ##### MESH_CONFIG ##### -->|${networkConnector}|" "$CONFIG_FILE"
+  fi
+}
+
+function configureAuthentication() {
+  username="${AMQ_USER}"
+  password="${AMQ_PASSWORD}"
+  dname="${AMQ_DNAME}"
+
+  if [ -n "${username}" -a -n "${dname}" ] ; then
+    sed -i "s|##### AUTHENTICATION #####|${username}=${dname}|" "${USERS_DNAME_FILE}"
+  fi
+  if [ -n "${username}" -a -n "${password}" ] ; then
+    sed -i "s|##### AUTHENTICATION #####|${username}=${password}|" "${USERS_FILE}"
+  fi
+
+  if [ -n "${username}" -a -n "${dname}" ] ; then
+    authentication="<jaasDualAuthenticationPlugin configuration=\"activemq\" sslConfiguration=\"activemq\"/>"
+  elif [ -n "${username}" -a -n "${password}" ] ; then
+    authentication="<jaasAuthenticationPlugin configuration=\"activemq\" />"
+  else
+    authentication="<jaasAuthenticationPlugin configuration=\"activemq-guest\" />"
+  fi
+  sed -i "s|<!-- ##### AUTHENTICATION ##### -->|${authentication}|" "$CONFIG_FILE"
+}
+
+function configureDestinations() {
+  IFS=',' read -a queues <<< ${AMQ_QUEUES}
+  IFS=',' read -a topics <<< ${AMQ_TOPICS}
+
+  if [ "${#queues[@]}" -ne "0" -o "${#topics[@]}" -ne "0" ]; then
+    destinations="<destinations>"
+    if [ "${#queues[@]}" -ne "0" ]; then
+      for queue in ${queues[@]}; do
+        destinations="${destinations}<queue physicalName=\"${queue}\"/>"
+      done
+    fi
+    if [ "${#topics[@]}" -ne "0" ]; then
+      for topic in ${topics[@]}; do
+        destinations="${destinations}<topic physicalName=\"${topic}\"/>"
+      done
+    fi
+    destinations="${destinations}</destinations>"
+    sed -i "s|<!-- ##### DESTINATIONS ##### -->|${destinations}|" "$CONFIG_FILE"
+  fi
+}
+
+function sslPartial() {
+  [ -n "$AMQ_KEYSTORE_TRUSTSTORE_DIR" -o -n "$AMQ_KEYSTORE" -o -n "$AMQ_TRUSTSTORE" -o -n "$AMQ_KEYSTORE_PASSWORD" -o -n "$AMQ_TRUSTSTORE_PASSWORD" ]
+}
+
+function sslEnabled() {
+  [ -n "$AMQ_KEYSTORE_TRUSTSTORE_DIR" -a -n "$AMQ_KEYSTORE" -a -n "$AMQ_TRUSTSTORE" -a -n "$AMQ_KEYSTORE_PASSWORD" -a -n "$AMQ_TRUSTSTORE_PASSWORD" ]
+}
+
+function configureSSL() {
+  sslDir=$(find_env "AMQ_KEYSTORE_TRUSTSTORE_DIR" "")
+  keyStoreFile=$(find_env "AMQ_KEYSTORE" "")
+  trustStoreFile=$(find_env "AMQ_TRUSTSTORE" "")
+  
+  if sslEnabled ; then
+    keyStorePassword=$(find_env "AMQ_KEYSTORE_PASSWORD" "")
+    trustStorePassword=$(find_env "AMQ_TRUSTSTORE_PASSWORD" "")
+
+    keyStorePath="$sslDir/$keyStoreFile"
+    trustStorePath="$sslDir/$trustStoreFile"
+
+    sslElement="<sslContext>\n\
+            <sslContext keyStore=\"file:$keyStorePath\"\n\
+                        keyStorePassword=\"$keyStorePassword\"\n\
+                        trustStore=\"file:$trustStorePath\"\n\
+                        trustStorePassword=\"$trustStorePassword\" />\n\
+        </sslContext>"
+
+    sed -i "s|<!-- ##### SSL_CONTEXT ##### -->|${sslElement}|" "$CONFIG_FILE"
+  elif sslPartial ; then
+    log_warning "Partial ssl configuration, the ssl context WILL NOT be configured."
+  fi
+}
+
+function configureStoreUsage() {
+  storeUsage=$(find_env "AMQ_STORAGE_USAGE_LIMIT" "100 gb")
+  sed -i "s|##### STORE_USAGE #####|${storeUsage}|" "$CONFIG_FILE"
+}
+
+function configureTransportOptions() {
+  IFS=',' read -a transports <<< $(find_env "AMQ_TRANSPORTS" "openwire,mqtt,amqp,stomp")
+  maxConnections=$(find_env "AMQ_MAX_CONNECTIONS" "1000")
+  maxFrameSize=$(find_env "AMQ_FRAME_SIZE" "104857600")
+
+  if [ "${#transports[@]}" -ne "0" ]; then
+    transportConnectors="<transportConnectors>"
+    for transport in ${transports[@]}; do
+      case "${transport}" in
+        "openwire")
+          transportConnectors="${transportConnectors}\n            <transportConnector name=\"openwire\" uri=\"tcp://0.0.0.0:61616?maximumConnections=${maxConnections}\&amp;wireFormat.maxFrameSize=${maxFrameSize}\" />"
+          if sslEnabled ; then
+            transportConnectors="${transportConnectors}\n            <transportConnector name=\"ssl\" uri=\"ssl://0.0.0.0:61617?maximumConnections=${maxConnections}\&amp;wireFormat.maxFrameSize=${maxFrameSize}" 
+            if [ -n "$AMQ_NEED_CLIENT_AUTH" ]; then
+              transportConnectors="${transportConnectors}\&amp;transport.needClientAuth=${AMQ_NEED_CLIENT_AUTH}"
+            fi
+            if [ -n "$AMQ_TRANSPORT_ENABLED_PROTOCOLS" ]; then
+              transportConnectors="${transportConnectors}\&amp;transport.enabledProtocols=${AMQ_TRANSPORT_ENABLED_PROTOCOLS}"
+            fi
+            transportConnectors="${transportConnectors}\"/>"
+          fi
+          ;;
+        "mqtt")
+          transportConnectors="${transportConnectors}\n            <transportConnector name=\"mqtt\" uri=\"mqtt://0.0.0.0:1883?maximumConnections=${maxConnections}\&amp;wireFormat.maxFrameSize=${maxFrameSize}\" />"
+          if sslEnabled ; then
+            transportConnectors="${transportConnectors}\n            <transportConnector name=\"mqtt+ssl\" uri=\"mqtt+ssl://0.0.0.0:8883?maximumConnections=${maxConnections}\&amp;wireFormat.maxFrameSize=${maxFrameSize}"
+            if [ -n "$AMQ_NEED_CLIENT_AUTH" ]; then
+              transportConnectors="${transportConnectors}\&amp;transport.needClientAuth=${AMQ_NEED_CLIENT_AUTH}"
+            fi
+            if [ -n "$AMQ_TRANSPORT_ENABLED_PROTOCOLS" ]; then
+              transportConnectors="${transportConnectors}\&amp;transport.enabledProtocols=${AMQ_TRANSPORT_ENABLED_PROTOCOLS}"
+            fi
+            transportConnectors="${transportConnectors}\"/>"
+          fi
+          ;;
+        "amqp")
+          transportConnectors="${transportConnectors}\n            <transportConnector name=\"amqp\" uri=\"amqp://0.0.0.0:5672?maximumConnections=${maxConnections}\&amp;wireFormat.maxFrameSize=${maxFrameSize}\" />"
+          if sslEnabled ; then
+            transportConnectors="${transportConnectors}\n            <transportConnector name=\"amqp+ssl\" uri=\"amqp+ssl://0.0.0.0:5671?maximumConnections=${maxConnections}\&amp;wireFormat.maxFrameSize=${maxFrameSize}"
+            if [ -n "$AMQ_NEED_CLIENT_AUTH" ]; then
+              transportConnectors="${transportConnectors}\&amp;transport.needClientAuth=${AMQ_NEED_CLIENT_AUTH}"
+            fi
+            if [ -n "$AMQ_TRANSPORT_ENABLED_PROTOCOLS" ]; then
+              transportConnectors="${transportConnectors}\&amp;transport.enabledProtocols=${AMQ_TRANSPORT_ENABLED_PROTOCOLS}"
+            fi
+            transportConnectors="${transportConnectors}\"/>"
+          fi
+          ;;
+        "stomp")
+          transportConnectors="${transportConnectors}\n            <transportConnector name=\"stomp\" uri=\"stomp://0.0.0.0:61613?maximumConnections=${maxConnections}\&amp;wireFormat.maxFrameSize=${maxFrameSize}\" />"
+          if sslEnabled ; then
+            transportConnectors="${transportConnectors}\n            <transportConnector name=\"stomp+ssl\" uri=\"stomp+ssl://0.0.0.0:61612?maximumConnections=${maxConnections}\&amp;wireFormat.maxFrameSize=${maxFrameSize}"
+            if [ -n "$AMQ_NEED_CLIENT_AUTH" ]; then
+              transportConnectors="${transportConnectors}\&amp;transport.needClientAuth=${AMQ_NEED_CLIENT_AUTH}"
+            fi
+            if [ -n "$AMQ_TRANSPORT_ENABLED_PROTOCOLS" ]; then
+              transportConnectors="${transportConnectors}\&amp;transport.enabledProtocols=${AMQ_TRANSPORT_ENABLED_PROTOCOLS}"
+            fi
+            transportConnectors="${transportConnectors}\"/>"
+          fi
+          ;;
+      esac
+    done
+    transportConnectors="${transportConnectors}\n        </transportConnectors>"
+    sed -i "s|<!-- ##### TRANSPORT_CONNECTORS ##### -->|${transportConnectors}|" "$CONFIG_FILE"
+  fi
+}
+
+# Only for AMQ63
+function configureIoExceptionHandler() {
+    if [[ "$JBOSS_AMQ_VERSION" == "6.3.0"* ]]; then
+        local EXCEPTION_HANDLER="\n        <ioExceptionHandler>\n            <defaultIOExceptionHandler ignoreNoSpaceErrors=\"false\"/>\n        </ioExceptionHandler>\n"
+        local LINE_TO_EDIT=`awk '/<\/managementContext>/{ print NR+1; exit }' "${CONFIG_FILE}"`
+        sed -i "${LINE_TO_EDIT}s|.*|${EXCEPTION_HANDLER}|" "${CONFIG_FILE}"
+    fi
+}
+
+function configurePolicy() {
+  if [ -n "$AMQ_QUEUE_MEMORY_LIMIT" ]; then
+    sed -i 's|memoryLimit *= *"[^"]*"|memoryLimit="'"${AMQ_QUEUE_MEMORY_LIMIT}"'"|' "$CONFIG_FILE"
+    sed -i "s|memoryLimit *= *'[^']*'|memoryLimit='${AMQ_QUEUE_MEMORY_LIMIT}'|" "$CONFIG_FILE"
+  fi
+}
+
+cp "${OPENSHIFT_CONFIG_FILE}" "${CONFIG_FILE}"
+cp "${OPENSHIFT_LOGIN_FILE}" "${LOGIN_FILE}"
+cp "${OPENSHIFT_USERS_FILE}" "${USERS_FILE}"
+cp "${OPENSHIFT_USERS_FILE}" "${USERS_DNAME_FILE}"
+
+configure_passwd
+configureAuthentication
+configureDestinations
+configureSSL
+configureStoreUsage
+configureTransportOptions
+checkViewEndpointsPermission
+configureMesh
+configureIoExceptionHandler
+configurePolicy

--- a/modules/md-amq-launch/added/drain.sh
+++ b/modules/md-amq-launch/added/drain.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+source $AMQ_HOME/bin/launch/logging.sh
+
+if [ "${SCRIPT_DEBUG}" = "true" ] ; then
+    set -x
+    log_info "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
+fi
+
+source $AMQ_HOME/bin/configure.sh
+source /opt/partition/partitionPV.sh
+source $AMQ_HOME/bin/drainClasspath.sh
+source /usr/local/dynamic-resources/dynamic_resources.sh
+
+ACTIVEMQ_OPTS="$(adjust_java_options ${ACTIVEMQ_OPTS})"
+
+ACTIVEMQ_OPTS="${ACTIVEMQ_OPTS} $(/opt/jolokia/jolokia-opts)"
+
+# Make sure that we use /dev/urandom
+ACTIVEMQ_OPTS="${ACTIVEMQ_OPTS} -Djava.security.egd=file:/dev/./urandom"
+
+# White list packages for use in ObjectMessages: CLOUD-703
+if [ -n "$MQ_SERIALIZABLE_PACKAGES" ]; then
+  ACTIVEMQ_OPTS="${ACTIVEMQ_OPTS} -Dorg.apache.activemq.SERIALIZABLE_PACKAGES=${MQ_SERIALIZABLE_PACKAGES}"
+fi
+
+# Add proxy command line options
+source /opt/run-java/proxy-options
+ACTIVEMQ_OPTS="$ACTIVEMQ_OPTS $(proxy_options)"
+opts_array=($ACTIVEMQ_OPTS)
+ACTIVEMQ_OPTS=$(printf "%q " ${opts_array[@]})
+
+function runMigration() {
+    export ACTIVEMQ_DATA="$1"
+
+    exec java -cp ${DRAIN_CLASSPATH} ${ACTIVEMQ_OPTS}  org.jboss.ce.amq.drain.BrokerServiceDrainer
+}
+
+DATA_DIR="${AMQ_HOME}/data"
+mkdir -p "${DATA_DIR}"
+
+migratePV "${DATA_DIR}"

--- a/modules/md-amq-launch/added/launch.sh
+++ b/modules/md-amq-launch/added/launch.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+source $AMQ_HOME/bin/launch/logging.sh
+
+if [ "${SCRIPT_DEBUG}" = "true" ] ; then
+    set -x
+    log_info "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
+fi
+
+source $AMQ_HOME/bin/configure.sh
+source /opt/partition/partitionPV.sh
+source /usr/local/dynamic-resources/dynamic_resources.sh
+
+ACTIVEMQ_OPTS="$(adjust_java_options ${ACTIVEMQ_OPTS})"
+
+ACTIVEMQ_OPTS="${ACTIVEMQ_OPTS} $(/opt/jolokia/jolokia-opts)"
+
+# Make sure that we use /dev/urandom
+ACTIVEMQ_OPTS="${ACTIVEMQ_OPTS} -Djava.security.egd=file:/dev/./urandom"
+
+# White list packages for use in ObjectMessages: CLOUD-703
+if [ -n "$MQ_SERIALIZABLE_PACKAGES" ]; then
+  ACTIVEMQ_OPTS="${ACTIVEMQ_OPTS} -Dorg.apache.activemq.SERIALIZABLE_PACKAGES=${MQ_SERIALIZABLE_PACKAGES}"
+fi
+
+# Add proxy command line options
+source /opt/run-java/proxy-options
+ACTIVEMQ_OPTS="$ACTIVEMQ_OPTS $(proxy_options)"
+opts_array=($ACTIVEMQ_OPTS)
+ACTIVEMQ_OPTS=$(printf "%q " ${opts_array[@]})
+
+# Add jolokia command line options
+cat <<EOF > $AMQ_HOME/bin/env
+ACTIVEMQ_OPTS="${ACTIVEMQ_OPTS} ${JAVA_OPTS_APPEND}"
+EOF
+
+log_info "Running $JBOSS_IMAGE_NAME image, version $JBOSS_IMAGE_VERSION"
+
+# Parameters are
+# - instance directory
+function runServer() {
+  # Fix log file
+  local instanceDir=$1
+  local log_file="$AMQ_HOME/conf/log4j.properties"
+  sed -i "s+activemq\.base}/data+activemq.data}+" "$log_file"
+
+  export ACTIVEMQ_DATA="$instanceDir"
+  exec "$AMQ_HOME/bin/activemq" console
+}
+
+function init_data_dir() {
+  # No init needed for AMQ
+  return
+}
+
+if [ "$AMQ_SPLIT" = "true" ]; then
+  DATA_DIR="${AMQ_HOME}/data"
+  mkdir -p "${DATA_DIR}"
+
+  partitionPV "${DATA_DIR}" "${AMQ_LOCK_TIMEOUT:-30}"
+else
+    exec $AMQ_HOME/bin/activemq console
+fi

--- a/modules/md-amq-launch/added/log4j.properties
+++ b/modules/md-amq-launch/added/log4j.properties
@@ -1,0 +1,78 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+## 
+## http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+#
+# This file controls most of the logging in ActiveMQ which is mainly based around 
+# the commons logging API.
+#
+log4j.rootLogger=INFO, console
+log4j.logger.org.apache.activemq.spring=WARN
+log4j.logger.org.apache.activemq.web.handler=WARN
+log4j.logger.org.springframework=WARN
+log4j.logger.org.apache.xbean=WARN
+log4j.logger.org.apache.camel=INFO
+log4j.logger.org.eclipse.jetty=WARN
+
+# When debugging or reporting problems to the ActiveMQ team,
+# comment out the above lines and uncomment the next.
+
+#log4j.rootLogger=DEBUG, logfile, console
+
+# Or for more fine grained debug logging uncomment one of these
+#log4j.logger.org.apache.activemq=DEBUG
+#log4j.logger.org.apache.camel=DEBUG
+
+# Console appender
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d | %5p | %m%n
+log4j.appender.console.threshold=INFO
+
+# File appender
+log4j.appender.logfile=org.apache.log4j.RollingFileAppender
+log4j.appender.logfile.file=${activemq.base}/data/activemq.log
+log4j.appender.logfile.maxFileSize=1024KB
+log4j.appender.logfile.maxBackupIndex=5
+log4j.appender.logfile.append=true
+log4j.appender.logfile.layout=org.apache.log4j.PatternLayout
+log4j.appender.logfile.layout.ConversionPattern=%d | %-5p | %m | %c | %t%n
+# use some of the following patterns to see MDC logging data
+#
+# %X{activemq.broker}
+# %X{activemq.connector}
+# %X{activemq.destination}
+#
+# e.g.
+#
+# log4j.appender.logfile.layout.ConversionPattern=%d | %-20.20X{activemq.connector} | %-5p | %m | %c | %t%n
+
+log4j.throwableRenderer=org.apache.log4j.EnhancedThrowableRenderer
+
+###########
+# Audit log
+###########
+
+log4j.additivity.org.apache.activemq.audit=false
+log4j.logger.org.apache.activemq.audit=INFO, audit
+
+log4j.appender.audit=org.apache.log4j.RollingFileAppender
+log4j.appender.audit.file=${activemq.base}/data/audit.log
+log4j.appender.audit.maxFileSize=1024KB
+log4j.appender.audit.maxBackupIndex=5
+log4j.appender.audit.append=true
+log4j.appender.audit.layout=org.apache.log4j.PatternLayout
+log4j.appender.audit.layout.ConversionPattern=%-5p | %m | %t%n

--- a/modules/md-amq-launch/added/openshift-activemq.xml
+++ b/modules/md-amq-launch/added/openshift-activemq.xml
@@ -1,0 +1,169 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+           http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+
+    <!-- Allows us to use system properties as variables in this configuration file -->
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="locations">
+            <value>file:${activemq.conf}/credentials.properties</value>
+        </property>
+    </bean>
+
+   	<!-- Allows accessing the server log -->
+    <bean id="logQuery" class="io.fabric8.insight.log.log4j.Log4jLogQuery"
+          lazy-init="false" scope="singleton"
+          init-method="start" destroy-method="stop">
+    </bean>
+
+    <!--
+        The <broker> element is used to configure the ActiveMQ broker.
+    -->
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="${HOSTNAME}" dataDirectory="${activemq.data}">
+
+        <!-- ##### DESTINATIONS ##### -->
+
+        <destinationPolicy>
+            <policyMap>
+                <policyEntries>
+                    <policyEntry queue=">" producerFlowControl="true" memoryLimit="1mb" maxBrowsePageSize="700">
+                        <!--
+                            Allow messages to be replayed back to original broker if there is demand.
+                            (replayWhenNoConsumers="true").
+                            Due to ENTMQ-444 you also want to configure a replayDelay that is high enough so that
+                            any outstanding message acks are passed along the network bridge *before* we start
+                            to replay messages (replayDelay="500"). The value of replayDelay is a bit of a guess but
+                            on a decently fast network 500 msecs should be enough to pass on and process all message acks.
+              
+                            Note: JMS clients that use the failover transport to connect to a broker in the mesh
+                            arbitrarily should consider using an initialReconnectDelay on the failover url that is
+                            higher than replayDelay configured in the broker. E.g.
+                            "failover:(tcp://brokerA:61616,tcp://brokerB:61616)?randomize=true&initialReconnectDelay=700"
+                            This ensures that the demand subscription for this reconnecting consumer is only created
+                            after replayDelay has elapsed.
+                            If its created before, it may lead to the remote broker skipping message dispatch
+                            to the remote broker and those message would seem to be stuck on the broker despite a consumer
+                            being connected via a networked broker.
+                            See ENTMQ-538 for more details.
+                        -->
+                        <networkBridgeFilterFactory>
+                            <conditionalNetworkBridgeFilterFactory replayWhenNoConsumers="true" replayDelay="500" />
+                        </networkBridgeFilterFactory>
+                    </policyEntry>
+                    <policyEntry topic=">" producerFlowControl="true">
+                        <!--
+                            The constantPendingMessageLimitStrategy is used to prevent
+                            slow topic consumers to block producers and affect other consumers
+                            by limiting the number of messages that are retained
+                            For more information, see:
+
+                            http://activemq.apache.org/slow-consumer-handling.html
+                        -->
+                        <pendingMessageLimitStrategy>
+                            <constantPendingMessageLimitStrategy limit="1000" />
+                        </pendingMessageLimitStrategy>
+                    </policyEntry>
+                </policyEntries>
+            </policyMap>
+        </destinationPolicy>
+
+        <!--
+            The managementContext is used to configure how ActiveMQ is exposed in
+            JMX. By default, ActiveMQ uses the MBean server that is started by
+            the JVM. For more information, see:
+
+            http://activemq.apache.org/jmx.html
+        -->
+        <managementContext>
+            <managementContext createConnector="false" />
+        </managementContext>
+
+        <networkConnectors>
+            <!--
+                In a full mesh we want messages to travel freely to any broker
+                (i.e. messageTTL="-1") but create demand subscription only to the next connected
+                broker (i.e. consumerTTL="1"). See AMQ-4607.
+            -->
+            <!-- ##### MESH_CONFIG ##### -->
+        </networkConnectors>
+
+        <!--
+            Configure message persistence for the broker. The default persistence
+            mechanism is the KahaDB store (identified by the kahaDB tag).
+            For more information, see:
+
+            http://activemq.apache.org/persistence.html
+        -->
+        <persistenceAdapter>
+            <kahaDB directory="${activemq.data}/kahadb" />
+        </persistenceAdapter>
+
+        <plugins>
+            <!-- ##### AUTHENTICATION ##### -->
+        </plugins>
+
+        <!--
+            The systemUsage controls the maximum amount of space the broker will
+            use before disabling caching and/or slowing down producers.
+            For more information, see:
+
+            http://activemq.apache.org/producer-flow-control.html
+        -->
+        <systemUsage>
+            <systemUsage>
+                <memoryUsage>
+                    <memoryUsage percentOfJvmHeap="70" />
+                </memoryUsage>
+                <storeUsage>
+                    <storeUsage limit="##### STORE_USAGE #####" />
+                </storeUsage>
+                <tempUsage>
+                    <tempUsage limit="50 gb" />
+                </tempUsage>
+            </systemUsage>
+        </systemUsage>
+
+        <!--
+            The transport connectors expose ActiveMQ over a given protocol to
+            clients and other brokers. For more information, see:
+
+            http://activemq.apache.org/configuring-transports.html
+        -->
+        <!-- ##### TRANSPORT_CONNECTORS ##### -->
+
+        <!-- ##### SSL_CONTEXT ##### -->
+
+        <!-- destroy the spring context on shutdown to stop jetty -->
+        <shutdownHooks>
+            <bean xmlns="http://www.springframework.org/schema/beans" class="org.apache.activemq.hooks.SpringContextHook" />
+        </shutdownHooks>
+
+    </broker>
+
+    <!--
+        Enable web consoles, REST and Ajax APIs and demos
+        The web consoles requires by default login, you can disable this in the jetty.xml file
+
+        Take a look at ${ACTIVEMQ_HOME}/conf/jetty.xml for more details
+    -->
+    <!-- Do not expose the console or other webapps
+    <import resource="jetty.xml" />
+    -->
+
+</beans>

--- a/modules/md-amq-launch/added/openshift-login.config
+++ b/modules/md-amq-launch/added/openshift-login.config
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+activemq {
+    org.apache.activemq.jaas.TextFileCertificateLoginModule sufficient
+        org.apache.activemq.jaas.textfiledn.user="users-dname.properties"
+        org.apache.activemq.jaas.textfiledn.group="groups.properties";
+   
+    org.apache.activemq.jaas.PropertiesLoginModule sufficient
+        org.apache.activemq.jaas.properties.user="users.properties"
+        org.apache.activemq.jaas.properties.group="groups.properties";
+
+};
+activemq-guest {
+    org.apache.activemq.jaas.PropertiesLoginModule sufficient
+        org.apache.activemq.jaas.properties.user="users.properties"
+        org.apache.activemq.jaas.properties.group="groups.properties";
+
+    org.apache.activemq.jaas.GuestLoginModule sufficient
+        org.apache.activemq.jaas.guest.user="user"
+        org.apache.activemq.jaas.guest.group="user";
+};
+

--- a/modules/md-amq-launch/added/openshift-users.properties
+++ b/modules/md-amq-launch/added/openshift-users.properties
@@ -1,0 +1,29 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the \"License\"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an \"AS IS\" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+#
+# This file contains the valid users who can log into JBoss A-MQ.
+# Each line has to be of the format:
+#
+# USER=PASSWORD
+#
+# You must have at least one users to be able to access JBoss A-MQ resources
+
+##### AUTHENTICATION #####
+

--- a/modules/md-amq-launch/added/readinessProbe.sh
+++ b/modules/md-amq-launch/added/readinessProbe.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+
+if [ true = "${DEBUG}" ] ; then
+    # short circuit readiness check in dev mode
+    exit 0
+fi
+
+OUTPUT=/tmp/readiness-output
+ERROR=/tmp/readiness-error
+LOG=/tmp/readiness-log
+
+CONFIG_FILE=$AMQ_HOME/conf/activemq.xml
+
+COUNT=30
+SLEEP=1
+DEBUG_SCRIPT=false
+
+EVALUATE_SCRIPT=`cat <<EOF
+import xml.etree.ElementTree
+from urlparse import urlsplit
+import socket
+import sys
+
+# calculate the open ports
+listening_ports = []
+inputs = ["/proc/net/tcp6", "/proc/net/tcp"]
+for input in inputs:
+  try:
+    tcp_file = open(input, "r")
+    tcp_lines = tcp_file.readlines()
+    header = tcp_lines.pop(0)
+    tcp_file.close()
+
+    for tcp_line in tcp_lines:
+      stripped = tcp_line.strip()
+      contents = stripped.split()
+      # Is the status listening?
+      if contents[3] == '0A':
+        netaddr = contents[1].split(":")
+        port = int(netaddr[1], 16)
+        listening_ports.append(port)
+
+  except IOError:
+   pass
+
+#parse the config file to retrieve the transport connectors
+xmldoc = xml.etree.ElementTree.parse("${CONFIG_FILE}")
+
+ns = {"core" : "http://activemq.apache.org/schema/core"}
+transportConnectors = xmldoc.findall("core:broker/core:transportConnectors/core:transportConnector", ns)
+
+result=0
+
+for transportConnector in transportConnectors:
+  name = transportConnector.get("name")
+  uri = transportConnector.get("uri")
+  spliturl = urlsplit(uri)
+  port = spliturl.port
+
+  print "{} port {}".format(name, port)
+
+  if port == None:
+    print "    {} does not define a port, cannot check transport".format(name)
+    continue
+
+  try:
+    listening_ports.index(port)
+    print "    Transport is listening on port {}".format(port)
+  except ValueError, e:
+    print "    Nothing listening on port {}, transport not yet running".format(port)
+    result=1
+sys.exit(result)
+EOF`
+
+if [ $# -gt 0 ] ; then
+    COUNT=$1
+fi
+
+if [ $# -gt 1 ] ; then
+    SLEEP=$2
+fi
+
+if [ $# -gt 2 ] ; then
+    DEBUG_SCRIPT=$3
+fi
+
+if [ true = "${DEBUG_SCRIPT}" ] ; then
+    echo "Count: ${COUNT}, sleep: ${SLEEP}" > "${LOG}"
+fi
+
+while : ; do
+    CONNECT_RESULT=1
+    PROBE_MESSAGE="No configuration file located: ${CONFIG_FILE}"
+
+    if [ -f "${CONFIG_FILE}" ] ; then
+        python -c "$EVALUATE_SCRIPT" >"${OUTPUT}" 2>"${ERROR}"
+
+        CONNECT_RESULT=$?
+        if [ true = "${DEBUG_SCRIPT}" ] ; then
+            (
+                echo "$(date) Connect: ${CONNECT_RESULT}"
+                echo "========================= OUTPUT =========================="
+                cat "${OUTPUT}"
+                echo "========================= ERROR =========================="
+                cat "${ERROR}"
+                echo "=========================================================="
+            ) >> "${LOG}"
+        fi
+
+        PROBE_MESSAGE="No transport listening on ports $(grep "Nothing listening" "${OUTPUT}" | sed -e 's+^.*on port ++' -e 's+,.*$++')"
+        rm -f  "${OUTPUT}" "${ERROR}"
+    fi
+
+    if [ "${CONNECT_RESULT}" -eq 0 ] ; then
+        exit 0;
+    fi
+
+    COUNT=$(expr "$COUNT" - 1)
+    if [ "$COUNT" -eq 0 ] ; then
+        echo ${PROBE_MESSAGE}
+        exit 1;
+    fi
+    sleep "${SLEEP}"
+done

--- a/modules/md-amq-launch/install.sh
+++ b/modules/md-amq-launch/install.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Launch script and related configuration
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ADDED_DIR=${SCRIPT_DIR}/added
+SOURCES_DIR="/tmp/artifacts"
+
+cp -p ${ADDED_DIR}/launch.sh ${ADDED_DIR}/configure.sh ${ADDED_DIR}/readinessProbe.sh ${ADDED_DIR}/drain.sh $AMQ_HOME/bin/
+cp -p ${ADDED_DIR}/openshift-activemq.xml ${ADDED_DIR}/openshift-login.config ${ADDED_DIR}/openshift-users.properties ${ADDED_DIR}/log4j.properties $AMQ_HOME/conf/
+cp -p ${SOURCES_DIR}/ce-amq-drain-1.0.0.Final-redhat-1.jar $AMQ_HOME/lib
+
+function findJar() {
+  AMQ_LIB="${AMQ_HOME}/lib"
+  JAR_NAME="$1"
+
+  JAR="$(find $AMQ_LIB -name ${JAR_NAME}\*.jar)"
+  if [ -n "${JAR}" -a -f "${JAR}" ] ; then
+    echo "${JAR}"
+  else
+    echo "Could not locate jar ${JAR_NAME}" >&2
+    exit 1
+  fi
+}
+
+DRAIN_CLASSPATH="$(findJar ce-amq-drain)"
+
+#for jar in activemq-client slf4j-api geronimo-jms_1.1_spec hawtbuf-1 geronimo-j2ee-management_1.1_spec \
+   #geronimo-jta_1.0.1B_spec activemq-jms-pool commons-pool geronimo-j2ee-connector_1.5_spec \
+   #log4j slf4j-log4j12
+for jar in activemq-broker activemq-client slf4j-api geronimo-jms_1.1_spec activemq-kahadb-store \
+   activemq-protobuf activemq-openwire-legacy openshift-activemq-plugin hawtbuf-1 \
+   geronimo-j2ee-management_1.1_spec slf4j-log4j12 log4j jboss-dmr
+do
+  DRAIN_CLASSPATH="${DRAIN_CLASSPATH}:$(findJar "$jar")"
+done
+
+echo "export DRAIN_CLASSPATH=${DRAIN_CLASSPATH}" > "${AMQ_HOME}/bin/drainClasspath.sh"

--- a/modules/md-amq-launch/module.yaml
+++ b/modules/md-amq-launch/module.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+name: md-amq-launch
+version: '1.0'
+description: Legacy md-amq-launch script package migrated from cct_module's os-amq-launch.
+modules:
+  install:
+  - name: os-java-run
+execute:
+- script: install.sh
+
+artifacts:
+- path: ce-amq-drain-1.0.0.Final-redhat-1.jar
+  md5: 65b9aba8e5a0b7d7b259a6028f85595e

--- a/modules/md-amq-optional/install.sh
+++ b/modules/md-amq-optional/install.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+SOURCES_DIR="/tmp/artifacts"
+
+cp -p "$SOURCES_DIR"/openshift-activemq-plugin-1.2.1.Final-redhat-1.jar $AMQ_HOME/lib/optional/
+cp -p "$SOURCES_DIR"/jboss-dmr-1.2.2.Final-redhat-1.jar $AMQ_HOME/lib/optional/

--- a/modules/md-amq-optional/module.yaml
+++ b/modules/md-amq-optional/module.yaml
@@ -1,0 +1,21 @@
+schema_version: 1
+name: md-amq-optional
+version: '1.0'
+description: Legacy md-amq-optional script package migrated from cct_module's os-amq-optional.
+execute:
+- script: install.sh
+envs:
+- name: AMQ_MESH_SERVICE_NAME
+  example: broker-amq-tcp
+- name: AMQ_MESH_DISCOVERY_TYPE
+  example: kube
+- name: AMQ_MESH_QUERY_INTERVAL
+  example: 30
+- name: AMQ_MESH_SERVICE_NAMESPACE
+  example: my-project
+
+artifacts:
+- path: openshift-activemq-plugin-1.2.1.Final-redhat-1.jar
+  md5: e250016affe0990f04b92cc9cea7578e
+- path: jboss-dmr-1.2.2.Final-redhat-1.jar
+  md5: 8df4cbf6f39c3bce21de16ad708084d5

--- a/modules/md-amq-permissions/install.sh
+++ b/modules/md-amq-permissions/install.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+for dir in $AMQ_HOME $HOME; do
+  chown -R jboss:root $dir
+  chmod -R g+rwX $dir
+done

--- a/modules/md-amq-permissions/module.yaml
+++ b/modules/md-amq-permissions/module.yaml
@@ -1,0 +1,6 @@
+schema_version: 1
+name: md-amq-permissions
+version: '1.0'
+description: Legacy md-amq-permissions script package migrated from cct_mdoule's os-amq-permissions
+execute:
+- script: install.sh

--- a/modules/md-amq-s2i/added/s2i/assemble
+++ b/modules/md-amq-s2i/added/s2i/assemble
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ "${SCRIPT_DEBUG}" = "true" ] ; then
+    set -x
+    echo "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
+fi
+
+SRCCONF=/tmp/src/configuration
+
+if [ -d ${SRCCONF} ]; then
+  echo "Copying config files from project..."
+  cp -v ${SRCCONF}/* $AMQ_HOME/conf/
+fi
+
+# Remove java tmp perf data dir owned by 185
+rm -rf /tmp/hsperfdata_jboss
+
+exit 0

--- a/modules/md-amq-s2i/install.sh
+++ b/modules/md-amq-s2i/install.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ADDED_DIR=${SCRIPT_DIR}/added
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R g+rwX $SCRIPT_DIR
+
+# Add s2i scripts and make the image S2I-enabled
+cp -pr ${ADDED_DIR}/s2i /usr/local
+chmod ug+x /usr/local/s2i/*

--- a/modules/md-amq-s2i/module.yaml
+++ b/modules/md-amq-s2i/module.yaml
@@ -1,0 +1,7 @@
+schema_version: 1
+name: md-amq-s2i
+version: '1.0'
+description: Legacy md-amq-s2i script package migrated from cct_module's os-amq-s2i.
+modules:
+  install:
+  - name: jboss.container.amq.s2i.bash

--- a/modules/md-amq-secure-mgmt-console/install.sh
+++ b/modules/md-amq-secure-mgmt-console/install.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Secure the management console
+# NOTE: the script package os-amq-launch contains code to configure management
+# console credentials and access at runtime.
+set -e
+
+sed -i -e 's/0.0.0.0/localhost/' $AMQ_HOME/conf/jetty.xml

--- a/modules/md-amq-secure-mgmt-console/module.yaml
+++ b/modules/md-amq-secure-mgmt-console/module.yaml
@@ -1,0 +1,6 @@
+schema_version: 1
+name: md-amq-secure-mgmt-console
+version: '1.0'
+description: Legacy md-amq-secure-mgmt-console script package migrated from cct_module's os-amq-secure-mgmt-console.
+execute:
+- script: install.sh


### PR DESCRIPTION
  This commit copies all dependent modules from cct_module repo
  and points modules to local directory.
  after that the build should no longer depends on cct_modules.

Signed-off-by: Howard Gao <howard.gao@gmail.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
